### PR TITLE
Game Flow Draft 2 w/ Time Machine

### DIFF
--- a/components/GameTab.vue
+++ b/components/GameTab.vue
@@ -4,7 +4,7 @@
     :class="[colorClasses, { active }]"
     :to="tabData.route"
   >
-    <span v-if="!tabData.locked" :class="tabData.label" />
+    <span v-if="tabData.unlocked" :class="tabData.label" />
     <span v-else class="fas fa-lock" />
   </nuxt-link>
 </template>

--- a/components/ProgressButton.vue
+++ b/components/ProgressButton.vue
@@ -17,6 +17,7 @@
       /
       <span v-if="unit === 'apprenticeLevels'">L</span>{{ maxText }}
       <span v-if="unit === 'spareTime'" class="fas fa-hourglass-half" />
+      <span v-if="unit === 'energy'" class="fas fa-bolt" />
     </span>
 
     <span

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -53,6 +53,7 @@ export default {
   },
   methods: {
     gametick() {
+      // Instruments tick
       this.$store.state.processes
         .filter((p) => p.created)
         .forEach((process, index) => {
@@ -65,6 +66,14 @@ export default {
 
           this.$store.commit('tickProcess', { process })
         })
+
+      // Energy ticks
+      if (
+        this.$store.getters.isTabUnlocked('Time Machine') &&
+        this.$store.state.energy < this.$store.state.energyMax
+      ) {
+        this.$store.commit('tickEnergy')
+      }
     },
   },
 }

--- a/pages/Apprentices.vue
+++ b/pages/Apprentices.vue
@@ -12,7 +12,7 @@
 export default {
   computed: {
     unlocked() {
-      return this.$store.state.processes.filter((p) => p.unlocked)
+      return this.$store.state.processes.filter((p) => p.unlocked && p.created)
     },
   },
 }

--- a/pages/Missions.vue
+++ b/pages/Missions.vue
@@ -68,8 +68,24 @@ export default {
   methods: {
     complete(mission) {
       this.$store.commit('completeMission', mission.name)
+
       if (mission.completionCriteria.unit === 'spareTime') {
         this.$store.commit('spendCurrency', mission.completionCriteria.value)
+      }
+
+      if (mission.name === 'Study Time Magic') {
+        this.$store.commit('unlockTab', 'Time Magic')
+      }
+
+      if (mission.name === 'Create the Time Machine') {
+        this.$store.commit('unlockTab', 'Time Machine')
+      }
+
+      if (mission.name === 'Time to Cheat Death') {
+        this.$store.commit('unlockTab', 'Wisdom')
+        this.$store.commit('setPlayerAge', { year: 30 })
+        this.$store.commit('timeTravel', { year: 1400 })
+        this.$store.commit('tickLifetime')
       }
     },
   },

--- a/pages/TimeMachine.vue
+++ b/pages/TimeMachine.vue
@@ -1,3 +1,69 @@
 <template>
-  <div>Tab 4 content</div>
+  <div class="md:pt-4 pt-2">
+    <div
+      class="energy-bar relative mx-auto rounded-full overflow-hidden border-2"
+      :class="`text-${$store.getters.activeTab.color} border-${$store.getters.activeTab.darkColor}`"
+    >
+      <progress
+        class="absolute top-0 right-0 left-0 w-full h-full"
+        :max="$store.state.energyMax"
+        :value="$store.state.energy"
+      />
+      <span
+        class="relative block pt-1 pb-2 text-center text-lg font-semibold"
+        :class="`text-${$store.getters.activeTab.darkColor}`"
+      >
+        <span class="mr-1"
+          >{{ $store.state.energy }} / {{ $store.state.energyMax }}</span
+        >
+        <span class="text-base pt-1 ml-2 fas fa-bolt" />
+      </span>
+    </div>
+
+    <responsive-grid class="pt-4 md:pt-8">
+      <progress-button
+        v-for="(action, index) in $store.state.timeMachineActions"
+        :key="index"
+        :label="action.name"
+        :description="action.description"
+        :max="action.cost"
+        :value="$store.state.energy"
+        @click="doAction(action)"
+      />
+    </responsive-grid>
+  </div>
 </template>
+
+<script>
+export default {
+  methods: {
+    doAction(action) {
+      this.$store.commit('spendEnergy', action.cost)
+      if (action.name === 'Activate!') {
+        // do action-specific things
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.energy-bar {
+  width: 75%;
+}
+/* progress bars for all browsers */
+progress::-webkit-progress-bar {
+  background-color: rgba(255, 255, 255, 0.1);
+  width: 100%;
+}
+progress {
+  color: currentColor;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+progress::-webkit-progress-value {
+  background-color: currentColor;
+}
+progress::-moz-progress-bar {
+  background-color: currentColor;
+}
+</style>

--- a/pages/TimeMagic.vue
+++ b/pages/TimeMagic.vue
@@ -1,3 +1,3 @@
 <template>
-  <div>Tab 5 content</div>
+  <div>Tab 5 content.</div>
 </template>

--- a/pages/Wisdom.vue
+++ b/pages/Wisdom.vue
@@ -13,8 +13,8 @@
       ><span align="right"></span>
     </div>
     <div>
-      <span align="left"><b>Total lifetimes</b></span
-      ><span align="right">{{ $store.state.totalLifetimes }}</span>
+      <span align="left"><b>Completed lifetimes</b></span
+      ><span align="right">{{ $store.state.lifetimes }}</span>
     </div>
     <div>
       <span align="left"><b>Longest lifetime</b></span

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,6 +38,10 @@ export default {
     create(process) {
       this.$store.commit('createInstrument', process.instrument)
       this.$store.commit('spendCurrency', process.cost)
+      if (process.instrument === 'Mechanical Clock') {
+        this.$store.commit('unlockTab', 'Apprentices')
+        this.$store.commit('unlockTab', 'Missions')
+      }
     },
   },
 }


### PR DESCRIPTION
Makes the game flow closer to the end product in the following ways:
- Instruments now cost spare time. We forgot this. Oops!
- First draft of time machine tab. Action costs work as expected, but the actions have no other functions yet.
- Dynamically unlock tabs based on the appropriate criteria
- "Time to Cheat Death" is now displayed under the appropriate conditions and also mostly functions as expected
-  Re-adjusted the numbers and some names for instruments, apprentices, and eras with Logan's live input. Locally, you can mark all instruments as unlocked to see how they feel with respect to one another.

Closes #63 

Closes #65 